### PR TITLE
Exclude junit from shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
@@ -66,6 +72,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Makes junit a test scope only dependency. Reduces final file size of Configuralize. Similar PR coming for DiscordSRV as well soon.

Please release a new version of configuralize to use in DiscordSRV after merging this PR.