### PR TITLE
Fix Shading Conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,26 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+            <!-- Produce the non-shaded (slim) JAR -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>slim-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>slim</classifier>
+                            <finalName>Configuralize-${project.version}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Produce the shaded (fat) JAR as the default artifact -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
Add support for building a slim jar without shaded dependencies.



This would fix https://github.com/Scarsz/Configuralize/issues/8 if the end user used the slim jar.

## Default Shaded JAR

Usage for existing developers would remain the same and complete backwards compatibility with existing projects is maintained.


<details>
<summary><b>Maven</b></summary>

```
xml
<dependency>
    <groupId>github.scarsz</groupId>
    <artifactId>configuralize</artifactId>
    <version>1.4.0</version>
</dependency>
```

</details>

<details>
<summary><b>Groovy DSL (Gradle)</b></summary>

```
groovy
dependencies {
    implementation 'github.scarsz:configuralize:1.4.0'
}
```

</details>

<details>
<summary><b>Kotlin DSL (Gradle)</b></summary>

```
kotlin
dependencies {
    implementation("github.scarsz:configuralize:1.4.0")
}
```

</details>

## Slim JAR (Non-Shaded, with Classifier)

Developers can opt to use the alternative `slim` JAR, which does not include shaded dependencies. This JAR uses the `slim` classifier.

<details>
<summary><b>Maven</b></summary>

```
xml
<dependency>
    <groupId>github.scarsz</groupId>
    <artifactId>configuralize</artifactId>
    <version>1.4.0</version>
    <classifier>slim</classifier>
</dependency>
```

</details>

<details>
<summary><b>Groovy DSL (Gradle)</b></summary>

```
groovy
dependencies {
    implementation 'github.scarsz:configuralize:1.4.0:slim'
}
```

</details>

<details>
<summary><b>Kotlin DSL (Gradle)</b></summary>

```
kotlin
dependencies {
    implementation("github.scarsz:configuralize:1.4.0:slim")
}
```

</details>

This also fixes support with JiJ conflicts. Some platforms like Fabric have it as standard to specify dependencies as Jars inside of your main jar instead of shading and/or relocating. With the existing shaded jar this causes conflicts if another plugin /mod depends on SnakeYAML code and tries to load it via JiJ only to find an incompatible one already loaded due to shading.